### PR TITLE
Fix the deploy

### DIFF
--- a/EC2-Commands.txt
+++ b/EC2-Commands.txt
@@ -24,26 +24,31 @@ $ ls
 $ unzip ServerFiles-2.44.zip
 //This will inflate/unzip your server files
 
-$ls
-//again check your files and you should now see a Server-Files-<version> without the .zip, we want to enter this file.
+$ sudo rpm --import https://yum.corretto.aws/corretto.key
+$ sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
+$ sudo yum install -y java-21-amazon-corretto-devel
+//Install JAVA21 (https://docs.aws.amazon.com/corretto/latest/corretto-21-ug/generic-linux-install.html#rpm-linux-install-instruct)
 
-$ cd <Server-Files-Folder-Found-In-ls-Command>
-//This line will put us inside the Server Files folder
+$ chmod u+x startserver.sh
+//give perms to run script
 
-//NOTE: If script doesn't start, try $ chmod u+x startserver.sh
-    //OR, try $ ./startserver.sh
+$ ./startserver.sh
+//this line will run the startserver file that should be located inside your Server-Files, while running this it will ask you to enable the EULA=TRUE
 
-$ sudo startserver.sh
-//this line will run the startserver file that should be located inside your Server-Files, while running this it will ask you to install Java, do that, and run it again,
-//if no work, enable in Amazon (https://docs.aws.amazon.com/corretto/latest/corretto-21-ug/generic-linux-install.html#rpm-linux-install-instruct)
+$ nano eula.txt
+//Set EULA=TRUE (Ctrl-O to save)
 
-& ./run.sh
+$ ./run.sh
 //This line will actually start your server, and will take a few minutes, once it's done have fun!
+
+// EDIT Minecraft startup JAVA settings 
+// $ nano user_jvm_args.txt
+
 
 
 If you'd like to backup your server run a command like this:
 $ aws s3 cp --recursive /minecraft/world/ s3://minecraft-file-store/worlds/
 //This file will recursively put every world file into your desired s3 bucket location, this it's important to keep backups in case of a server crash.
 
-To remove your would files you just need to overwrite the world files inside your Server-Files, the command should look something like this:
+To remove your world files - overwrite the world files inside your Server-Files, the command should look something like this:
 aws s3 sync s3://minecraft-file-store/worlds/ /minecraft/world/

--- a/EC2-Commands.txt
+++ b/EC2-Commands.txt
@@ -10,19 +10,29 @@ Commands:
     // Use $ ls -ald /minecraft to check perms, should read= "drwxrwxrwx 2 root root *DATE* /minecraft"
 $ mkdir /minecraft
 //This is purely for organization, it's just creating a file, which keeps things nicely organized
+
 $ cd /minecraft
 //This command will put you inside your newly created Minecraft directory
+
 $ aws s3 cp s3://minecraft-file-store/ServerFiles-2.44.zip /minecraft
 //This line will import your s3 bucket server file into your ec2 terminal, this line is formatted like this: s3:// (this is the S3 URL to your Server-Files which can be found in your bucket) "/minecraft" is telling the computer to put
 // your files in the /minecraft directory that was created
+
 $ ls
 // This is a very useful command and will tell you if you've done everything correctly so far, if you see your Server-Files zip when entering this command then everything is going according to plan.
-$ unzip <Server-Files-Name-Here>
+
+$ unzip ServerFiles-2.44.zip
 //This will inflate/unzip your server files
+
 $ls
 //again check your files and you should now see a Server-Files-<version> without the .zip, we want to enter this file.
+
 $ cd <Server-Files-Folder-Found-In-ls-Command>
 //This line will put us inside the Server Files folder
+
+//NOTE: If script doesn't start, try $ chmod u+x startserver.sh
+    //OR, try $ ./startserver.sh
+
 $ sudo startserver.sh
 //this line will run the startserver file that should be located inside your Server-Files, while running this it will ask you to install Java, do that, and run it again,
 & ./run.sh

--- a/EC2-Commands.txt
+++ b/EC2-Commands.txt
@@ -12,7 +12,7 @@ $ mkdir /minecraft
 //This is purely for organization, it's just creating a file, which keeps things nicely organized
 $ cd /minecraft
 //This command will put you inside your newly created Minecraft directory
-$ aws s3 cp s3://<s3-Bucket-Name-Here>/Server-Files<Version>.zip /minecraft
+$ aws s3 cp s3://minecraft-file-store/ServerFiles-2.44.zip /minecraft
 //This line will import your s3 bucket server file into your ec2 terminal, this line is formatted like this: s3:// (this is the S3 URL to your Server-Files which can be found in your bucket) "/minecraft" is telling the computer to put
 // your files in the /minecraft directory that was created
 $ ls

--- a/EC2-Commands.txt
+++ b/EC2-Commands.txt
@@ -35,6 +35,8 @@ $ cd <Server-Files-Folder-Found-In-ls-Command>
 
 $ sudo startserver.sh
 //this line will run the startserver file that should be located inside your Server-Files, while running this it will ask you to install Java, do that, and run it again,
+//if no work, enable in Amazon (https://docs.aws.amazon.com/corretto/latest/corretto-21-ug/generic-linux-install.html)
+
 & ./run.sh
 //This line will actually start your server, and will take a few minutes, once it's done have fun!
 

--- a/EC2-Commands.txt
+++ b/EC2-Commands.txt
@@ -5,6 +5,9 @@ Format:
 - Anything with "$" in front of it is a command to be entered into the Ec2 Linux Terminal.
 
 Commands:
+//NOTE: If perm denied, just $ sudo mkdir /minecraft
+    // If more write perms are needed - $ sudo chmod a+w /minecraft
+    // Use $ ls -ald /minecraft to check perms, should read= "drwxrwxrwx 2 root root *DATE* /minecraft"
 $ mkdir /minecraft
 //This is purely for organization, it's just creating a file, which keeps things nicely organized
 $ cd /minecraft

--- a/EC2-Commands.txt
+++ b/EC2-Commands.txt
@@ -42,8 +42,8 @@ $ sudo startserver.sh
 
 
 If you'd like to backup your server run a command like this:
-$ aws s3 cp --recursive /minecraft/<Server-Files-Folder>/world/ s3://<s3 URL to where you'd like to back up your world save to>
+$ aws s3 cp --recursive /minecraft/world/ s3://minecraft-file-store/worlds/
 //This file will recursively put every world file into your desired s3 bucket location, this it's important to keep backups in case of a server crash.
 
 To remove your would files you just need to overwrite the world files inside your Server-Files, the command should look something like this:
-aws s3 sync s3://<s3 url to world backup folder> /minecraft/<server-Files-Version>/world/
+aws s3 sync s3://minecraft-file-store/worlds/ /minecraft/world/

--- a/EC2-Commands.txt
+++ b/EC2-Commands.txt
@@ -35,7 +35,7 @@ $ cd <Server-Files-Folder-Found-In-ls-Command>
 
 $ sudo startserver.sh
 //this line will run the startserver file that should be located inside your Server-Files, while running this it will ask you to install Java, do that, and run it again,
-//if no work, enable in Amazon (https://docs.aws.amazon.com/corretto/latest/corretto-21-ug/generic-linux-install.html)
+//if no work, enable in Amazon (https://docs.aws.amazon.com/corretto/latest/corretto-21-ug/generic-linux-install.html#rpm-linux-install-instruct)
 
 & ./run.sh
 //This line will actually start your server, and will take a few minutes, once it's done have fun!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Minecraft-AWS-Server
-Commands used to create, and manage my AWS 1.20.1 All The Mods 9 Minecraft Modded Server
+Commands used to create, and manage my AWS 1.21.1 All The Mods 10 Minecraft Modded Server
 
 Important Setup:
 Step 1: Install Modded Minecraft Server Files:


### PR DESCRIPTION
EC2 commands don't work - 

To install JAVA 21 via AWS is now:

$ sudo rpm --import https://yum.corretto.aws/corretto.key
$ sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
$ sudo yum install -y java-21-amazon-corretto-devel
//Install JAVA21 (https://docs.aws.amazon.com/corretto/latest/corretto-21-ug/generic-linux-install.html#rpm-linux-install-instruct)

Accept EULA is:

$ nano eula.txt
//Set EULA=TRUE (Ctrl-O to save)


And added some further fallbacks when errors occur.